### PR TITLE
Port to older Python

### DIFF
--- a/cygport/core.py
+++ b/cygport/core.py
@@ -116,7 +116,7 @@ def main ( argv = sys.argv ) :
         args['<cygport-file>'] = argv[idx] = cygports[0]
 
     cygport_idx = argv.index(args['<cygport-file>'])
-    argx = [ * argv[:cygport_idx+1] ]
+    argx = list(argv[:cygport_idx+1])
     commands = args['<command>']
     # print(f"i : argx  = {argx}")
     # print(f"commands  = {commands}")
@@ -148,10 +148,10 @@ def main ( argv = sys.argv ) :
         argz = []
         if logging:
             n = ordinals.get(command, n_unknown)
-            argz = [ 'logts', '-t', '-b', f"log/{n}.{command}" ]
-        argz += [ *argx, command ]
-        print(f"+ {' '.join(argz)}\n")
-        subprocess.run(argz)
+            argz = ['logts', '-t', '-b', 'log/{}.{}'.format(n, command)]
+        argz += argx + [command]
+        print("+ {}\n".format(' '.join(argz)))
+        subprocess.call(argz)
         print()
 
 #------------------------------------------------------------------------------

--- a/flat/cygport.py
+++ b/flat/cygport.py
@@ -156,7 +156,7 @@ def main ( argv = sys.argv ) :
         args['<cygport-file>'] = argv[idx] = cygports[0]
 
     cygport_idx = argv.index(args['<cygport-file>'])
-    argx = [ * argv[:cygport_idx+1] ]
+    argx = list(argv[:cygport_idx+1])
     commands = args['<command>']
     # print(f"i : argx  = {argx}")
     # print(f"commands  = {commands}")
@@ -188,10 +188,10 @@ def main ( argv = sys.argv ) :
         argz = []
         if logging:
             n = ordinals.get(command, n_unknown)
-            argz = [ 'logts', '-t', '-b', f"log/{n}.{command}" ]
-        argz += [ *argx, command ]
-        print(f"+ {' '.join(argz)}\n")
-        subprocess.run(argz)
+            argz = ['logts', '-t', '-b', 'log/{}.{}'.format(n, command)]
+        argz += argx + [command]
+        print("+ {}\n".format(' '.join(argz)))
+        subprocess.call(argz)
         print()
 
 sys.exit(main(sys.argv))

--- a/tasks.py
+++ b/tasks.py
@@ -117,7 +117,7 @@ def format(c, top='src'):
     start()
     for python_file in python_source_files(top='src/.'):
         # -a <= --aggressive : enough to pass flake8
-        verbose_run(c, f"autopep8 --in-place -aaaaaaaa {python_file}")
+        verbose_run(c, "autopep8 --in-place -aaaaaaaa {}".format(python_file))
     separator()
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- support running on Python 3.2 by avoiding newer syntax
- adjust helper script for compatibility
- update autopep8 invocation in tasks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'plumbum')*

------
https://chatgpt.com/codex/tasks/task_b_684b965928e083268c27125ae4f0e18c