### PR TITLE
Remove shim imports

### DIFF
--- a/flat/cygport.py
+++ b/flat/cygport.py
@@ -57,7 +57,7 @@ import os
 import subprocess
 import sys
 
-from docopt import docopt
+from cygport.vendor import docopt
 from glob import glob
 from pprint import PrettyPrinter
 
@@ -137,7 +137,7 @@ ordinals = {
 
 def main ( argv = sys.argv ) :
 
-    args = docopt(__doc__, argv=argv[1:], options_first=True, version=__version__ )
+    args = docopt.docopt(__doc__, argv=argv[1:], options_first=True, version=__version__ )
 
     argv[0] = CYGPORT_COMMAND
 

--- a/src/cygport/core.py
+++ b/src/cygport/core.py
@@ -65,7 +65,7 @@ import subprocess
 from glob import glob
 from copy import copy
 
-from docopt import docopt
+from .vendor import docopt
 
 from cygport import __version__
 
@@ -97,7 +97,7 @@ ordinals = {
 
 def main ( argv = sys.argv ) :
 
-    args = docopt(__doc__, argv=argv[1:], options_first=True, version=__version__ )
+    args = docopt.docopt(__doc__, argv=argv[1:], options_first=True, version=__version__ )
 
     argv[0] = CYGPORT_COMMAND
 

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -15,7 +15,7 @@ os.environ['CYGPORT_COMMAND'] = str(Path(__file__).resolve().parents[1] / 'scrip
 
 import unittest
 
-from plumbum import local, FG, BG, RETCODE
+from cygport.vendor.miniplumbum import local, BG, RETCODE
 
 from chdir import ChDir
 from ansi import ansi_escape


### PR DESCRIPTION
## Summary
- import vendored docopt module instead of shim
- import vendored miniplumbum module in tests

## Testing
- `make test` *(fails: ModuleNotFoundError: No module named 'setuptools')*

------
https://chatgpt.com/codex/tasks/task_b_684c029909248326a05dc80a97daad41