### PR TITLE
Port to Python 3.2.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 docopt
 plumbum
+pathlib2; python_version < '3.4'

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -1,6 +1,9 @@
 import sys
 
-from pathlib import Path
+try:
+    from pathlib import Path
+except ImportError:  # Python < 3.4
+    from pathlib2 import Path
 
 import unittest
 


### PR DESCRIPTION
## Summary
- import `pathlib2` when the standard `pathlib` is missing
- add `pathlib2` to requirements for older Pythons

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'plumbum')*

------
https://chatgpt.com/codex/tasks/task_b_684c2f4e22cc832698a3278a227532a7